### PR TITLE
Support box shadow to multi (only drop shadow)

### DIFF
--- a/packages/reflect-core/lib/column/column.ts
+++ b/packages/reflect-core/lib/column/column.ts
@@ -18,7 +18,7 @@ export class Column extends Flex {
         p: Omit<IFlexManifest, "direction"> & {
             key: WidgetKey;
             //
-            boxShadow?: BoxShadowManifest;
+            boxShadow?: BoxShadowManifest[];
             margin?: EdgeInsets;
             padding?: EdgeInsets;
             background?: Background;

--- a/packages/reflect-core/lib/container/container.ts
+++ b/packages/reflect-core/lib/container/container.ts
@@ -6,7 +6,7 @@ import type { BorderRadiusManifest, DimensionLength, EdgeInsets } from "../";
 import { DefaultStyleWidget, WidgetKey } from "../widget";
 
 export interface IContainerInitializerProps {
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     width?: number;
     height?: number;
     margin?: EdgeInsets;
@@ -45,7 +45,7 @@ export class Container extends DefaultStyleWidget {
     visible: boolean = true;
 
     // effects
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     background?: Background;
 
     constructor({

--- a/packages/reflect-core/lib/flex/flex.ts
+++ b/packages/reflect-core/lib/flex/flex.ts
@@ -70,7 +70,7 @@ export class Flex
         mainAxisAlignment?: MainAxisAlignment;
         mainAxisSize?: MainAxisSize;
         //
-        boxShadow?: BoxShadowManifest;
+        boxShadow?: BoxShadowManifest[];
         margin?: EdgeInsets;
         padding?: EdgeInsets;
         background?: Background;

--- a/packages/reflect-core/lib/rect/rect.manifest.ts
+++ b/packages/reflect-core/lib/rect/rect.manifest.ts
@@ -23,5 +23,5 @@ export interface CGRectManifest {
         strokeWidth: number;
     };
 
-    shadow?: BoxShadowManifest;
+    shadow?: BoxShadowManifest[];
 }

--- a/packages/reflect-core/lib/rect/rect.manifest.ts
+++ b/packages/reflect-core/lib/rect/rect.manifest.ts
@@ -23,5 +23,5 @@ export interface CGRectManifest {
         strokeWidth: number;
     };
 
-    shadow?: BoxShadowManifest[];
+    shadow?: BoxShadowManifest;
 }

--- a/packages/reflect-core/lib/row/row.ts
+++ b/packages/reflect-core/lib/row/row.ts
@@ -17,7 +17,7 @@ export class Row extends Flex {
         p: Omit<IFlexManifest, "direction"> & {
             key: WidgetKey;
             //
-            boxShadow?: BoxShadowManifest;
+            boxShadow?: BoxShadowManifest[];
             margin?: EdgeInsets;
             padding?: EdgeInsets;
             background?: Background;

--- a/packages/reflect-core/lib/stack/stack.ts
+++ b/packages/reflect-core/lib/stack/stack.ts
@@ -12,7 +12,7 @@ export class Stack extends DefaultStyleMultiChildRenderObjectWidget {
 
     width: number;
     height: number;
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     clipBehavior?: Clip;
     children: Widget[];
 
@@ -21,7 +21,7 @@ export class Stack extends DefaultStyleMultiChildRenderObjectWidget {
         children: Widget[];
         width: number;
         height: number;
-        boxShadow?: BoxShadowManifest;
+        boxShadow?: BoxShadowManifest[];
         borderRadius?: BorderRadiusManifest;
         border?: Border;
         margin?: EdgeInsets;

--- a/packages/reflect-core/lib/widget/default-style-widget.ts
+++ b/packages/reflect-core/lib/widget/default-style-widget.ts
@@ -23,7 +23,7 @@ export interface IPositionedWidget {
 }
 
 export interface IBoxShadowWidget {
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
 }
 
 export interface IEdgeInsetsWidget {
@@ -38,7 +38,7 @@ export interface IDefaultStyleWidget
         IEdgeInsetsWidget {}
 
 export interface IDefaultStyleInitializerProps {
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     width?: number;
     height?: number;
     margin?: EdgeInsets;
@@ -58,7 +58,7 @@ export class DefaultStyleMultiChildRenderObjectWidget
     x?: number;
     y?: number;
     /// IBoxShadowWidget
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     // IEdgeInsetsWidget
     padding?: EdgeInsets;
     margin?: EdgeInsets;
@@ -118,7 +118,7 @@ export class DefaultStyleWidget
     x?: number;
     y?: number;
     /// IBoxShadowWidget
-    boxShadow?: BoxShadowManifest;
+    boxShadow?: BoxShadowManifest[];
     // IEdgeInsetsWidget
     padding?: EdgeInsets;
     margin?: EdgeInsets;


### PR DESCRIPTION
support box-shadow to multi (only drop shadow, inner shadow is not supported yet)

before
<img width="967" alt="Screen Shot 2021-11-09 at 8 45 41 PM" src="https://user-images.githubusercontent.com/40289200/140918484-f6a6bf71-e625-4d53-a08a-e03c8feadc53.png">

after
<img width="871" alt="Screen Shot 2021-11-10 at 4 40 05 AM" src="https://user-images.githubusercontent.com/40289200/141053784-ab14e369-d0ff-45d7-a759-407c82d42487.png">

